### PR TITLE
fix printing issue when argument is invalid name

### DIFF
--- a/R/spmd_tool.r
+++ b/R/spmd_tool.r
@@ -19,6 +19,10 @@ spmd.comm.print <- function(x, all.rank = .pbdMPIEnv$SPMD.CT$print.all.rank,
     barrier = .pbdMPIEnv$SPMD.CT$msg.barrier, con = stdout(), ...){
   COMM.RANK <- spmd.comm.rank(comm)
 
+  # Don't print "COMM.RANK = " even if verbose=TRUE in the case 'x' is invalid
+  if (!exists(deparse(substitute(x))))
+    quiet <- TRUE
+
   if(barrier){
     spmd.barrier(comm)
   }


### PR DESCRIPTION
This fixes the micro-bug of printing the rank while verbose before erroring on invalid object name. 

Before PR:
```
> comm.print(an_object_that_doesnt_exist)
COMM.RANK = 0
Error in print(x, ...) : object 'an_object_that_doesnt_exist' not found
```

After PR:
```
> comm.print(an_object_that_doesnt_exist)
Error in print(x, ...) : object 'an_object_that_doesnt_exist' not found
```

I'm not sure how to fix this for `comm.cat()`, but it's less used anyway so maybe we can just leave it alone.