### PR TITLE
Fix namspace export for .pbd_env

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pbdMPI
-Version: 0.3-2
-Date: 2016-07-13
+Version: 0.3-3
+Date: 2016-07-14
 Title: Programming with Big Data -- Interface to MPI
 Authors@R: c(person("Wei-Chen", "Chen", role = c("aut", "cre"), email =
         "wccsnow@gmail.com"),
@@ -18,7 +18,8 @@ Enhances: pbdPROF, pbdZMQ
 LazyLoad: yes
 LazyData: yes
 Description: An efficient interface to MPI by utilizing S4
-        classes and methods with a focus on Single Program/Multiple Data ('SPMD')
+        classes and methods with a focus on Single Program/Multiple Data
+        ('SPMD')
         parallel programming style, which is intended for batch parallel
         execution.
 SystemRequirements: OpenMPI (>= 1.5.4) on Solaris, Linux, Mac, and

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -78,10 +78,10 @@ export(
   "task.pull",
 
   ### "R/000_pbd_opt.r"
-  "pbd_opt",
+  "pbd_opt" #,
 
   ### "R/222_export_env.r"
-  ".pbd_env"
+  #".pbd_env"
 )
 
 S3method(comm.sort, default)


### PR DESCRIPTION
Mac OSX with R-devel does not like to export not exist object.