### PR TITLE
Create alias for spmd.comm.create.errhandler

### DIFF
--- a/R/spmd_communicator.r
+++ b/R/spmd_communicator.r
@@ -11,6 +11,8 @@ spmd.comm.set.errhandler <- function(comm = .pbd_env$SPMD.CT$comm){
   invisible(ret)
 } # End of spmd.comm.set.errhandler().
 
+comm.set.errhandler <- spmd.comm.set.errhandler
+
 spmd.comm.is.null <- function(comm = .pbd_env$SPMD.CT$comm){
   .Call("spmd_comm_is_null", as.integer(comm), PACKAGE = "pbdMPI")
 } # End of spmd.comm.is.null().

--- a/src/zzz.c
+++ b/src/zzz.c
@@ -44,7 +44,6 @@ static const R_CallMethodDef callMethods[] = {
 
 	/* In file "spmd_communicator_spawn.c". */
 	{"spmd_comm_spawn", (DL_FUNC) &spmd_comm_spawn, 6},
-	{"spmd_comm_spawn", (DL_FUNC) &spmd_comm_spawn, 6},
 
 	/* In file "spmd_allgather.c". */
 	{"spmd_allgather_integer", (DL_FUNC) &spmd_allgather_integer, 3},


### PR DESCRIPTION
This commit creates alias comm.create.errhandler to spmd.comm.create.errhandler for consistency with the other routines in R/spmd_communicator.r

(note that comm.create.errhandler isn't documented in the pbdMPI user guide)

This PR also addresses the (seemingly benign) issue of a duplicate R_CallMethodDef for spmd_comm_spawn().